### PR TITLE
Fix for blank page in IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "webpack": "^4.12.0",
     "webpack-cli": "^3.0.8",
     "webpack-dev-server": "^3.1.4",
-    "webpack-merge": "^4.1.3"
+    "webpack-merge": "^4.1.3",
+    "core-js": "^2.4.0"
   },
   "dependencies": {
     "interactjs": "^1.3.4",

--- a/src/timeline.js
+++ b/src/timeline.js
@@ -15,6 +15,9 @@ import Timebar from './components/timebar';
 import SelectBox from './components/selector';
 import {DefaultGroupRenderer, DefaultItemRenderer} from './components/renderers';
 
+// startsWith polyfill for IE11 support
+import 'core-js/fn/string/starts-with';
+
 import './style.css';
 
 export default class Timeline extends Component {


### PR DESCRIPTION
Import String.prototype.startsWith polyfill from core-js to fix failure to render under IE11.

Hello!
Remember to increment the version number in `package.json` if merging to release :)
