### PR TITLE
namespace dom queries to prevent 2 rosters on a page breaking each other

### DIFF
--- a/src/timeline.js
+++ b/src/timeline.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import ReactDOM from 'react-dom';
 import {Grid, AutoSizer, defaultCellRangeRenderer} from 'react-virtualized';
 
 import moment from 'moment';
@@ -45,6 +46,7 @@ export default class Timeline extends React.Component {
     snapMinutes: PropTypes.number,
     showCursorTime: PropTypes.bool,
     cursorTimeFormat: PropTypes.string,
+    componentId: PropTypes.string, // A unique key to identify the component. Only needed when 2 grids are mounted
     itemHeight: PropTypes.number,
     timelineMode: PropTypes.number,
     timebarFormat: PropTypes.object,
@@ -66,6 +68,7 @@ export default class Timeline extends React.Component {
     itemHeight: 40,
     snapMinutes: 15,
     cursorTimeFormat: 'D MMM YYYY HH:mm',
+    componentId: 'r9k1',
     showCursorTime: true,
     groupRenderer: DefaultGroupRenderer,
     itemRenderer: DefaultItemRenderer,
@@ -273,11 +276,12 @@ export default class Timeline extends React.Component {
   };
 
   setUpDragging(canSelect, canDrag, canResize) {
+    const topDivId = `rct9k-id-${this.props.componentId}`;
     if (this._itemInteractable) this._itemInteractable.unset();
     if (this._selectRectangleInteractable) this._selectRectangleInteractable.unset();
 
-    this._itemInteractable = interact('.item_draggable');
-    this._selectRectangleInteractable = interact('.parent-div');
+    this._itemInteractable = interact(`.${topDivId} .item_draggable`);
+    this._selectRectangleInteractable = interact(`.${topDivId} .parent-div`);
 
     this._itemInteractable.on('tap', e => {
       this._handleItemRowEvent(e, this.props.onItemClick, this.props.onRowClick);
@@ -297,7 +301,7 @@ export default class Timeline extends React.Component {
           );
 
           _.forEach(animatedItems, id => {
-            let domItem = document.querySelector("span[data-item-index='" + id + "'");
+            let domItem = this._gridDomNode.querySelector("span[data-item-index='" + id + "'");
             if (domItem) {
               selections.push([this.getItem(id).start, this.getItem(id).end]);
               domItem.setAttribute('isDragging', 'True');
@@ -310,7 +314,7 @@ export default class Timeline extends React.Component {
         })
         .on('dragmove', e => {
           const target = e.target;
-          let animatedItems = document.querySelectorAll("span[isDragging='True'") || [];
+          let animatedItems = this._gridDomNode.querySelectorAll("span[isDragging='True'") || [];
 
           let dx = (parseFloat(target.getAttribute('drag-x')) || 0) + e.dx;
           let dy = (parseFloat(target.getAttribute('drag-y')) || 0) + e.dy;
@@ -351,7 +355,7 @@ export default class Timeline extends React.Component {
         })
         .on('dragend', e => {
           const {item, rowNo} = this.itemFromElement(e.target);
-          let animatedItems = document.querySelectorAll("span[isDragging='True'") || [];
+          let animatedItems = this._gridDomNode.querySelectorAll("span[isDragging='True'") || [];
 
           this.setSelection([[item.start, item.end]]);
           this.clearSelection();
@@ -419,7 +423,7 @@ export default class Timeline extends React.Component {
         .on('resizestart', e => {
           const selected = this.props.onInteraction(Timeline.changeTypes.resizeStart, null, this.props.selectedItems);
           _.forEach(selected, id => {
-            let domItem = document.querySelector("span[data-item-index='" + id + "'");
+            let domItem = this._gridDomNode.querySelector("span[data-item-index='" + id + "'");
             if (domItem) {
               domItem.setAttribute('isResizing', 'True');
               domItem.setAttribute('initialWidth', pixToInt(domItem.style.width));
@@ -428,7 +432,7 @@ export default class Timeline extends React.Component {
           });
         })
         .on('resizemove', e => {
-          let animatedItems = document.querySelectorAll("span[isResizing='True'") || [];
+          let animatedItems = this._gridDomNode.querySelectorAll("span[isResizing='True'") || [];
 
           let dx = parseFloat(e.target.getAttribute('delta-x')) || 0;
           dx += e.deltaRect.left;
@@ -461,7 +465,7 @@ export default class Timeline extends React.Component {
           e.target.setAttribute('delta-x', dx);
         })
         .on('resizeend', e => {
-          let animatedItems = document.querySelectorAll("span[isResizing='True'") || [];
+          let animatedItems = this._gridDomNode.querySelectorAll("span[isResizing='True'") || [];
           // Update time
           const dx = parseFloat(e.target.getAttribute('delta-x')) || 0;
           const isStartTimeChange = dx != 0;
@@ -706,18 +710,19 @@ export default class Timeline extends React.Component {
 
   /**
    * Set the grid ref.
-   * @param {Object} domElement Grid react element
+   * @param {Object} reactComponent Grid react element
    */
-  grid_ref_callback(domElement) {
-    this._grid = domElement;
+  grid_ref_callback(reactComponent) {
+    this._grid = reactComponent;
+    this._gridDomNode = ReactDOM.findDOMNode(this._grid);
   }
 
   /**
    * Set the select box ref.
-   * @param {Object} domElement Selectbox react element
+   * @param {Object} reactComponent Selectbox react element
    */
-  select_ref_callback(domElement) {
-    this._selectBox = domElement;
+  select_ref_callback(reactComponent) {
+    this._selectBox = reactComponent;
   }
 
   /**
@@ -747,8 +752,9 @@ export default class Timeline extends React.Component {
   }
 
   render() {
-    const {onInteraction, groupOffset, timebarFormat} = this.props;
+    const {onInteraction, groupOffset, timebarFormat, componentId} = this.props;
 
+    const divCssClass = `rct9k-timeline-div rct9k-id-${componentId}`;
     let varTimebarProps = {};
     if (timebarFormat) varTimebarProps['timeFormats'] = timebarFormat;
 
@@ -760,7 +766,7 @@ export default class Timeline extends React.Component {
     }
 
     return (
-      <div className="rct9k-timeline-div">
+      <div className={divCssClass}>
         <AutoSizer onResize={this.refreshGrid}>
           {({height, width}) => (
             <div className="parent-div" onMouseMove={this.mouseMoveFunc}>

--- a/src/utils/itemUtils.js
+++ b/src/utils/itemUtils.js
@@ -70,12 +70,14 @@ export function rowItemsRenderer(items, vis_start, vis_end, total_width, itemHei
  * Gets the row number for a given x and y pixel location
  * @param  {number} x The x coordinate of the pixel location
  * @param  {number} y The y coordinate of the pixel location
+ * @param  {Object} topDiv Div to search under
  * @returns {number} The row number
  */
-export function getNearestRowHeight(x, y) {
+export function getNearestRowHeight(x, y, topDiv = document) {
   let elementsAtPixel = document.elementsFromPoint(x, y);
   let targetRow = _.find(elementsAtPixel, e => {
-    return e.hasAttribute('data-row-index');
+    const inDiv = topDiv.contains(e);
+    return inDiv && e.hasAttribute('data-row-index');
   });
   return targetRow ? targetRow.getAttribute('data-row-index') : 0;
 }


### PR DESCRIPTION
## Proposed Change:
Namespace dom queries so 2 timelines can be mounted without interfering with each other

## Change type

_Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature

