### PR TITLE
Selection fix

### DIFF
--- a/src/timeline.js
+++ b/src/timeline.js
@@ -624,6 +624,7 @@ export default class Timeline extends React.Component {
         })
         .on('dragend', e => {
           let {top, left, width, height} = this._selectBox.end();
+          const {componentId} = this.props;
           //Get the start and end row of the selection rectangle
           const topRowObject = getNearestRowObject(left, top);
           if (topRowObject !== undefined) {
@@ -639,8 +640,10 @@ export default class Timeline extends React.Component {
             );
             //Get the start and end time of the selection rectangle
             left = left - this.props.groupOffset;
-            let startOffset = width > 0 ? left : left + width;
-            let endOffset = width > 0 ? left + width : left;
+            const leftOffset = document.querySelector(`.rct9k-id-${componentId} .parent-div`).getBoundingClientRect()
+              .left;
+            const startOffset = left - leftOffset;
+            const endOffset = e.clientX - this.props.groupOffset - leftOffset;
             const startTime = getTimeAtPixel(
               startOffset,
               this.props.startDate,
@@ -664,7 +667,13 @@ export default class Timeline extends React.Component {
                 })
               );
             }
-            this.props.onInteraction(Timeline.changeTypes.itemsSelected, selectedItems);
+
+            this.props.onInteraction(Timeline.changeTypes.itemsSelected, selectedItems, {
+              startTime,
+              endTime,
+              rowTopIndex: topRowNumber,
+              rowBottomIndex: bottomRow
+            });
           }
         });
     }

--- a/src/timeline.js
+++ b/src/timeline.js
@@ -80,7 +80,9 @@ export default class Timeline extends React.Component {
     groupRenderer: PropTypes.func,
     groupTitleRenderer: PropTypes.func,
     shallowUpdateCheck: PropTypes.bool,
-    forceRedrawFunc: PropTypes.func
+    forceRedrawFunc: PropTypes.func,
+    bottomResolution: PropTypes.string,
+    topResolution: PropTypes.string
   };
 
   static defaultProps = {
@@ -833,12 +835,16 @@ export default class Timeline extends React.Component {
       shallowUpdateCheck,
       forceRedrawFunc,
       startDate,
-      endDate
+      endDate,
+      bottomResolution,
+      topResolution
     } = this.props;
 
     const divCssClass = `rct9k-timeline-div rct9k-id-${componentId}`;
     let varTimebarProps = {};
     if (timebarFormat) varTimebarProps['timeFormats'] = timebarFormat;
+    if (bottomResolution) varTimebarProps['bottom_resolution'] = bottomResolution;
+    if (topResolution) varTimebarProps['top_resolution'] = topResolution;
 
     function columnWidth(width) {
       return ({index}) => {


### PR DESCRIPTION
## Proposed Change:
When timeline is placed with the left margin to the web page it breaks the calculation on the "dragend" event, so that the selection of events is broken, as the start and end time are shifted.

This pool request fixes that issue and also adds the selected time frame and rows to the callback "onInteraction" function: 

```
onInteraction(key, selectedItems, {
              startTime,
              endTime,
              rowTopIndex,
              rowBottomIndex
});
```

Now users will be able to use the selected range for creating events, for example.

## Change type

_Put an `x` in the boxes that apply_

- [x] Bugfix
- [x] New feature

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [] I have added necessary documentation (if appropriate)
