### PR TITLE
Fix selection when timeline is horizontally positioned

### DIFF
--- a/src/timeline.js
+++ b/src/timeline.js
@@ -638,7 +638,7 @@ export default class Timeline extends React.Component {
               )
             );
             //Get the start and end time of the selection rectangle
-            left = left - this.props.groupOffset;
+            left = left - topRowLoc.left;
             let startOffset = width > 0 ? left : left + width;
             let endOffset = width > 0 ? left + width : left;
             const startTime = getTimeAtPixel(


### PR DESCRIPTION
## Proposed Change:
Fix #200

This fix assumes that both top and bottom rows have the same bounding box

## Change type

_Put an `x` in the boxes that apply_

- [x ] Bugfix
- [ ] New feature

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
