### PR TITLE
Restrict drag area to only within the grid area

### DIFF
--- a/src/timeline.js
+++ b/src/timeline.js
@@ -324,6 +324,10 @@ export default class Timeline extends React.Component {
     });
 
     if (canDrag) {
+      const innerGridHeight = this._grid 
+        ? _this4._gridDomNode.querySelector(".ReactVirtualized__Grid__innerScrollContainer")
+          .getBoundingClientRect().height 
+        : 0;
       this._itemInteractable
         .draggable({
           enabled: true,
@@ -333,7 +337,7 @@ export default class Timeline extends React.Component {
             elementRect: {left: 0, right: 1, top: 0, bottom: 1},
             offset: {
               left: this.props.groupOffset,
-              bottom: this._grid ? this._grid.props.height - Math.min(this.props.itemHeight * this.props.groups.length, this._grid.props.height) : 0
+              bottom: this._grid ? this._grid.props.height - Math.min(innerGridHeight, this._grid.props.height) : 0
             },
           }
         })

--- a/src/timeline.js
+++ b/src/timeline.js
@@ -329,8 +329,12 @@ export default class Timeline extends React.Component {
           enabled: true,
           allowFrom: selectedItemSelector,
           restrict: {
-            restriction: `.${topDivClassId}`,
-            elementRect: {left: 0, right: 1, top: 0, bottom: 1}
+            restriction: `.${topDivClassId}  .ReactVirtualized__Grid`,
+            elementRect: {left: 0, right: 1, top: 0, bottom: 1},
+            offset: {
+              left: this.props.groupOffset,
+              bottom: this._grid ? this._grid.props.height - Math.min(this.props.itemHeight * this.props.groups.length, this._grid.props.height) : 0
+            },
           }
         })
         .on('dragstart', e => {


### PR DESCRIPTION
## Proposed Change:

Currently items can be dragged over groups and outside the bounds of the grid

This restricts the drag area to only regions with valid groups within the grid area.

**Sidenote**: This PR is also the first step in getting auto vertical scrolling enabled.

## Change type

- [x] Bugfix
- [ ] New feature

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
