### PR TITLE
Fix clickedTime on rows when Timeline has horizontal padding

### DIFF
--- a/src/timeline.js
+++ b/src/timeline.js
@@ -682,7 +682,7 @@ export default class Timeline extends React.Component {
     } else {
       let row = e.target.getAttribute('data-row-index');
       let clickedTime = getTimeAtPixel(
-        e.clientX - this.props.groupOffset,
+        e.clientX - e.target.getBoundingClientRect().x,
         this.props.startDate,
         this.props.endDate,
         this.getTimelineWidth()


### PR DESCRIPTION
## Proposed Change:

The clicked time is incorrect when horizontal padding is applied to the timeline.

It now calculates based upon the row screen X position, instead of the width of the sidebar

## Change type

- [x] Bugfix
- [ ] New feature

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
