### PR TITLE
Fix Timebar for React 17.x

### DIFF
--- a/src/components/timebar.js
+++ b/src/components/timebar.js
@@ -16,14 +16,12 @@ export default class Timebar extends React.Component {
     this.state = {};
 
     this.guessResolution = this.guessResolution.bind(this);
+    this.guessResolution();
     this.renderBar = this.renderBar.bind(this);
     this.renderTopBar = this.renderTopBar.bind(this);
     this.renderBottomBar = this.renderBottomBar.bind(this);
   }
 
-  componentWillMount() {
-    this.guessResolution();
-  }
   /**
    * On new props we check if a resolution is given, and if not we guess one
    * @param {Object} nextProps Props coming in


### PR DESCRIPTION
## Proposed Change:

As per https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html componentWillMount was removed in React 17.

Moved to logic to the constructor as per migration instructions.

## Change type

_Put an `x` in the boxes that apply_

- [x] Bugfix
- [ ] New feature

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
