### PR TITLE
Refactor Timebar to remove legacy lifecycle hooks (Fix broken React 17.x)

### DIFF
--- a/src/components/timebar.js
+++ b/src/components/timebar.js
@@ -13,27 +13,11 @@ import {timebarFormat as defaultTimebarFormat} from '../consts/timebarConsts';
 export default class Timebar extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {};
 
     this.guessResolution = this.guessResolution.bind(this);
     this.renderBar = this.renderBar.bind(this);
     this.renderTopBar = this.renderTopBar.bind(this);
     this.renderBottomBar = this.renderBottomBar.bind(this);
-  }
-
-  componentWillMount() {
-    this.guessResolution();
-  }
-  /**
-   * On new props we check if a resolution is given, and if not we guess one
-   * @param {Object} nextProps Props coming in
-   */
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.top_resolution && nextProps.bottom_resolution) {
-      this.setState({resolution: {top: nextProps.top_resolution, bottom: nextProps.bottom_resolution}});
-    } else {
-      this.guessResolution(nextProps.start, nextProps.end);
-    }
   }
 
   /**
@@ -49,31 +33,31 @@ export default class Timebar extends React.Component {
     }
     const durationSecs = end.diff(start, 'seconds');
     //    -> 1h
-    if (durationSecs <= 60 * 60) this.setState({resolution: {top: 'hour', bottom: 'minute'}});
+    if (durationSecs <= 60 * 60) return { top: 'hour', bottom: 'minute'};
     // 1h -> 3d
-    else if (durationSecs <= 24 * 60 * 60 * 3) this.setState({resolution: {top: 'day', bottom: 'hour'}});
+    else if (durationSecs <= 24 * 60 * 60 * 3) return { top: 'day', bottom: 'hour'};
     // 1d -> 30d
-    else if (durationSecs <= 30 * 24 * 60 * 60) this.setState({resolution: {top: 'month', bottom: 'day'}});
+    else if (durationSecs <= 30 * 24 * 60 * 60) return { top: 'month', bottom: 'day'};
     //30d -> 1y
-    else if (durationSecs <= 365 * 24 * 60 * 60) this.setState({resolution: {top: 'year', bottom: 'month'}});
+    else if (durationSecs <= 365 * 24 * 60 * 60) return { top: 'year', bottom: 'month'};
     // 1y ->
-    else this.setState({resolution: {top: 'year', bottom: 'year'}});
+    else return { top: 'year', bottom: 'year'};
   }
 
   /**
    * Renderer for top bar.
    * @returns {Object} JSX for top menu bar - based of time format & resolution
    */
-  renderTopBar() {
-    let res = this.state.resolution.top;
+  renderTopBar(resolution) {
+    let res = resolution.top;
     return this.renderBar({format: this.props.timeFormats.majorLabels[res], type: res});
   }
   /**
    * Renderer for bottom bar.
    * @returns {Object} JSX for bottom menu bar - based of time format & resolution
    */
-  renderBottomBar() {
-    let res = this.state.resolution.bottom;
+  renderBottomBar(resolution) {
+    let res = resolution.bottom;
     return this.renderBar({format: this.props.timeFormats.minorLabels[res], type: res});
   }
   /**
@@ -185,8 +169,16 @@ export default class Timebar extends React.Component {
    */
   render() {
     const {cursorTime} = this.props;
-    const topBarComponent = this.renderTopBar();
-    const bottomBarComponent = this.renderBottomBar();
+    
+    const topResolution = this.props.top_resolution;
+    const bottomResolution = this.props.bottom_resolution;
+
+    const resolution = (topResolution && bottomResolution)
+      ? { top: topResolution, bottom: bottomResolution }
+      : this.guessResolution(this.props.start, this.props.end)
+    
+    const topBarComponent = this.renderTopBar(resolution);
+    const bottomBarComponent = this.renderBottomBar(resolution);
     const GroupTitleRenderer = this.props.groupTitleRenderer;
 
     // Only show the cursor on 1 of the top bar segments


### PR DESCRIPTION
## Proposed Change:

See: https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html

A number of lifecycle hooks have been deprecated, and one is removed in React 17.x which causing this library to break.

After examining the code and running some performance profiling I found that these hooks were not needed and it runs fractionally faster without them.

## Change type

- [x] Bugfix
- [ ] New feature

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
