### PR TITLE
Add new prop interactOptions

### DIFF
--- a/src/timeline.js
+++ b/src/timeline.js
@@ -83,7 +83,11 @@ export default class Timeline extends React.Component {
     forceRedrawFunc: PropTypes.func,
     bottomResolution: PropTypes.string,
     topResolution: PropTypes.string,
-    interact: PropTypes.object,
+    interactOptions: PropTypes.shape({
+      draggable: PropTypes.object,
+      pointerEvents: PropTypes.object,
+      resizable: PropTypes.object.isRequired,
+    }),
   };
 
   static defaultProps = {
@@ -102,7 +106,7 @@ export default class Timeline extends React.Component {
     forceRedrawFunc: null,
     onItemHover() {},
     onItemLeave() {},
-    interact: {},
+    interactOptions: {},
   };
 
   /**

--- a/src/timeline.js
+++ b/src/timeline.js
@@ -83,6 +83,7 @@ export default class Timeline extends React.Component {
     forceRedrawFunc: PropTypes.func,
     bottomResolution: PropTypes.string,
     topResolution: PropTypes.string,
+    interact.Props.object,
   };
 
   static defaultProps = {
@@ -101,6 +102,7 @@ export default class Timeline extends React.Component {
     forceRedrawFunc: null,
     onItemHover() {},
     onItemLeave() {},
+    interact: {},
   };
 
   /**
@@ -324,9 +326,11 @@ export default class Timeline extends React.Component {
     this._itemInteractable = interact(`.${topDivClassId} .item_draggable`);
     this._selectRectangleInteractable = interact(`.${topDivClassId} .parent-div`);
 
-    this._itemInteractable.on('tap', e => {
-      this._handleItemRowEvent(e, this.props.onItemClick, this.props.onRowClick);
-    });
+    this._itemInteractable
+      .pointerEvents(this.props.interactOptions.pointerEvents)
+      .on('tap', e => {
+        this._handleItemRowEvent(e, this.props.onItemClick, this.props.onRowClick);
+      });
 
     if (canDrag) {
       this._itemInteractable
@@ -337,6 +341,7 @@ export default class Timeline extends React.Component {
             restriction: `.${topDivClassId}`,
             elementRect: {left: 0, right: 1, top: 0, bottom: 1},
           },
+          ...this.props.interactOptions.draggable,
         })
         .on('dragstart', e => {
           let selections = [];
@@ -464,6 +469,7 @@ export default class Timeline extends React.Component {
         .resizable({
           allowFrom: selectedItemSelector,
           edges: {left: true, right: true, bottom: false, top: false},
+          ...this.props.interactOptions.draggable,
         })
         .on('resizestart', e => {
           const selected = this.props.onInteraction(Timeline.changeTypes.resizeStart, null, this.props.selectedItems);

--- a/src/timeline.js
+++ b/src/timeline.js
@@ -83,7 +83,7 @@ export default class Timeline extends React.Component {
     forceRedrawFunc: PropTypes.func,
     bottomResolution: PropTypes.string,
     topResolution: PropTypes.string,
-    interact: Props.object,
+    interact: PropTypes.object,
   };
 
   static defaultProps = {

--- a/src/timeline.js
+++ b/src/timeline.js
@@ -83,7 +83,7 @@ export default class Timeline extends React.Component {
     forceRedrawFunc: PropTypes.func,
     bottomResolution: PropTypes.string,
     topResolution: PropTypes.string,
-    interact.Props.object,
+    interact: Props.object,
   };
 
   static defaultProps = {


### PR DESCRIPTION
## Proposed Change:

Add the new prop `interactOptions` which allows customisation of `interactjs`

This prop is an object with 3 possible keys,

`pointerEvents`: Allow setting custom `interactjs.pointEvents` options
`draggable`: Allow setting custom `interactjs.draggable` options
`resizable`: Allow setting custom `interactjs.resizable` options

Example usage

```
const interactOptions = {
  pointerEvents: {
    ignoreFrom: '[no-pointer-event]', // Prevent the item selected callbacks when clicking on these elements
  },
  resizable: {
    cursorChecker (action) { // Use custom cursors
      if (action.edges.left) { return 'w-resize'}
      if (action.edges.right) { return 'e-resize'}
    }
  }
}

<Timeline {...props} interactOptions={interactOptions}/>
```

## Change type

- [ ] Bugfix
- [x] New feature

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
