### PR TITLE
Added "core-js" v2.4.0  as a regular dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "webpack-merge": "^4.1.3"
   },
   "dependencies": {
+    "core-js": "^2.4.0",
     "interactjs": "^1.6.2",
     "lodash": "^4.17.19",
     "moment": "^2.22.2",


### PR DESCRIPTION
## Why?

1) When the library is compiled, the generated code (by babel) "requires" "core-js". Honestly I'm not sure if this is needed, but the "require" is there.
2) When using the lib in a project (e.g. a modern "create-react-app" based one), a newer version of "core-js" (v3+) is present in "myProj/node_modules".
3) Because "core-js" v2 seems to be really incompatible w/ v3, and because of 1) and because this lib doesn't explicitly declare a dep towards "core-js" v2 => error as startup.

## Solution

This commits simply declares "core-js" as a regular dep (which was previously declared only as a dev dep). Because of this, during 2) yarn will download "core-js" v2 and add it as a "local" dep, in "myProj/node_modules/react-timeline-9000/node_modules". And thus the lib is happy.
I didn't have enough time to see a) how babel could be configured to prevent outputing the "requires" at step 1) or b) to increment the babel version, that would probably lead to a newer version of "core-js".